### PR TITLE
feat: Implement conversation encryption and update related services, …

### DIFF
--- a/packages/prisma/migrations/20250619052628_conversation_ecryption/migration.sql
+++ b/packages/prisma/migrations/20250619052628_conversation_ecryption/migration.sql
@@ -1,0 +1,20 @@
+-- AlterTable
+ALTER TABLE "Conversation" ADD COLUMN     "encryptionMetadataId" TEXT;
+
+-- CreateTable
+CREATE TABLE "encryption_metadata" (
+    "id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "conversation_id" TEXT NOT NULL,
+    "encryptionKey" VARCHAR(255) NOT NULL,
+    "iv" VARCHAR(255),
+
+    CONSTRAINT "encryption_metadata_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "encryption_metadata_conversation_id_key" ON "encryption_metadata"("conversation_id");
+
+-- AddForeignKey
+ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_encryptionMetadataId_fkey" FOREIGN KEY ("encryptionMetadataId") REFERENCES "encryption_metadata"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma/migrations/20250619053915_fix_encryption_metadata/migration.sql
+++ b/packages/prisma/migrations/20250619053915_fix_encryption_metadata/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `conversation_id` on the `encryption_metadata` table. All the data in the column will be lost.
+  - You are about to drop the column `created_at` on the `encryption_metadata` table. All the data in the column will be lost.
+  - You are about to drop the column `encryptionKey` on the `encryption_metadata` table. All the data in the column will be lost.
+  - You are about to drop the column `updated_at` on the `encryption_metadata` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "encryption_metadata_conversation_id_key";
+
+-- AlterTable
+ALTER TABLE "encryption_metadata" DROP COLUMN "conversation_id",
+DROP COLUMN "created_at",
+DROP COLUMN "encryptionKey",
+DROP COLUMN "updated_at",
+ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "mac" TEXT,
+ADD COLUMN     "version" TEXT DEFAULT 'v1';

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -160,10 +160,23 @@ model Conversation {
   thread Thread @relation(fields: [threadId], references: [id], onDelete: Cascade)
   sender User   @relation("SentConversations", fields: [senderId], references: [id], onDelete: Cascade)
 
-  conversationStatus ConversationStatus[]
+  conversationStatus   ConversationStatus[]
+  encryptionMetadata   EncryptionMetadata?  @relation(fields: [encryptionMetadataId], references: [id])
+  encryptionMetadataId String?
 
   @@index([threadId])
   @@index([senderId])
+}
+
+model EncryptionMetadata {
+  id           String         @id @default(cuid())
+  iv           String?        @db.VarChar(255) // Initialization Vector (base64)
+  version      String?        @default("v1")
+  mac          String? // Message Authentication Code (optional)
+  createdAt    DateTime       @default(now())
+  Conversation Conversation[]
+
+  @@map("encryption_metadata")
 }
 
 model ConversationStatus {

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -7,6 +7,7 @@ export * from './src/user/friend-ship';
 
 export * from './src/conversation/conversation';
 export * from './src/conversation/conversation-status';
+export * from './src/conversation/conversation-encryption';
 
 export * from './src/thread/thread';
 export * from './src/thread/thread-participant';

--- a/packages/types/src/conversation/conversation-encryption.ts
+++ b/packages/types/src/conversation/conversation-encryption.ts
@@ -1,0 +1,11 @@
+import type { EncryptionMetadata } from '@prisma/client';
+
+export type ConversationEncryptionRequest = {
+    mac: string;
+    version: string;
+    iv: string;
+};
+
+export interface ConversationEncryptionPublic extends Omit<EncryptionMetadata, 'encryptionKey'> {
+
+}

--- a/packages/types/src/conversation/conversation-status.ts
+++ b/packages/types/src/conversation/conversation-status.ts
@@ -1,5 +1,6 @@
-import type { Conversation, ConversationStatus } from '@prisma/client';
+import type { Conversation, ConversationStatus, EncryptionMetadata } from '@prisma/client';
 import type { ConversationPublic } from './conversation';
+import type { ConversationEncryptionPublic } from './conversation-encryption';
 
 export interface ConversationStatusRequest {
   // conversationId: string;
@@ -8,7 +9,8 @@ export interface ConversationStatusRequest {
   isEdited?: boolean;
 }
 
-export interface ConversationStatusPublic extends Omit<ConversationStatus, 'deletedAt' | 'createdAt' | 'editedAt' | 'readAt'> {}
+export interface ConversationStatusPublic extends Omit<ConversationStatus, 'deletedAt' | 'createdAt' | 'editedAt' | 'readAt'> {
+}
 
 export interface ConversationOverviewStatus {
   conversation: Omit<ConversationPublic, 'status'>;

--- a/packages/types/src/conversation/conversation.ts
+++ b/packages/types/src/conversation/conversation.ts
@@ -1,10 +1,12 @@
 import type { Conversation, ConversationStatus, Profile, User } from '@prisma/client';
 import type { ConversationOverviewStatus, ConversationStatusPublic } from 'packages/types';
+import type { ConversationEncryptionPublic, ConversationEncryptionRequest } from './conversation-encryption';
 
 export type ConversationRequest = {
   content: string;
   senderId: string;
   threadId: string;
+  encryptionMetadata?: ConversationEncryptionRequest;
 };
 
 export interface ConversationUserProfile {
@@ -16,6 +18,7 @@ export interface ConversationUserProfile {
 export interface ConversationPublic extends Omit<Conversation, 'updatedAt' | 'threadId' | 'senderId'> {
   // sender: ConversationUserProfile;
   sender?: ConversationUserProfile;
+  encryptionMetadata?: ConversationEncryptionPublic;
   status?: ConversationStatusPublic;
 }
 
@@ -28,12 +31,13 @@ export namespace ConversationModelMapper {
     };
   }
 
-  export function fromConversationToConversationPublic(conversation: Conversation & { sender?: User & { profile?: Profile } }, status?: ConversationStatusPublic): ConversationPublic {
+  export function fromConversationToConversationPublic(conversation: Conversation & { sender?: User & { profile?: Profile } }, status?: ConversationStatusPublic, encryptionMetadata?: ConversationEncryptionPublic): ConversationPublic {
     const { threadId, senderId, ...rest } = conversation;
     return {
       ...rest,
       sender: conversation.sender ? fromUserToConversationUserProfile(conversation.sender) : undefined,
       status,
+      encryptionMetadata,
     };
   }
 }

--- a/packages/types/src/zod/schema.ts
+++ b/packages/types/src/zod/schema.ts
@@ -63,10 +63,23 @@ export const friendshipSchema = z.object({
     }
 );
 
+export const conversationEncryptionSchema = z.object({
+    mac: z.string().min(1, "MAC is required"),
+    version: z.string().min(1, "Version is required"),
+    iv: z.string().min(1, "IV is required"),
+}).refine(
+    (data) => !!data.mac && !!data.version && !!data.iv,
+    {
+        message: "MAC, version, and IV are required.",
+        path: ['mac', 'version', 'iv'],
+    }
+);
+
 export const conversationThreadSchema = z.object({
     threadId: z.string().min(1, "Thread ID is required"),
     content: z.string().min(1, "Content is required").max(5000),
-    senderId: z.string().min(1, "Sender ID is required")
+    senderId: z.string().min(1, "Sender ID is required"),
+    encryptionMetadata: conversationEncryptionSchema.optional(),
 })
 
 export const threadSchema = z.object({


### PR DESCRIPTION
This pull request introduces encryption support for conversations, ensuring secure storage and transmission of conversation data. The changes include updates to the database schema, service logic, and test utilities to handle encryption metadata. Below are the most important changes grouped by theme:

### Database and Schema Updates:
* Added a new `EncryptionMetadata` model in the Prisma schema to store encryption-related data (`mac`, `version`, `iv`) and linked it to the `Conversation` model via a foreign key (`encryptionMetadataId`). [[1]](diffhunk://#diff-56fa4d384ba6fb94b130e9eb42c5cad00734b025ebd6c197f76873469725ae87R164-R181) [[2]](diffhunk://#diff-bb9ddc3caae10990cf9bf3d008ef2e90ab453e5d2e635dd086c7509769d0b0acR1-R20)
* Modified the `Conversation` model to include an optional relationship with `EncryptionMetadata`.
* Updated the `conversationThreadSchema` to validate optional encryption metadata using a new `conversationEncryptionSchema`.

### Service Logic Enhancements:
* Updated `ConversationService` to handle encryption metadata during conversation creation and updates. This includes creating and linking encryption metadata records in the database. [[1]](diffhunk://#diff-f7b3c757616537cc8d8a9641c151e17af8bda04cd5df64a761d4d5519a4f7f24L9-R40) [[2]](diffhunk://#diff-f7b3c757616537cc8d8a9641c151e17af8bda04cd5df64a761d4d5519a4f7f24R111-R112) [[3]](diffhunk://#diff-f7b3c757616537cc8d8a9641c151e17af8bda04cd5df64a761d4d5519a4f7f24L133-R140)
* Ensured encryption metadata is included in the conversation response by updating the `fromConversationToConversationPublic` mapper.

### Test Enhancements:
* Added utility functions (`generateAppKeyPair`, `generateMessage`, `decryptMessage`) to handle encryption and decryption in tests.
* Introduced a new test case to verify that conversation content is encrypted and can be decrypted correctly.

### Type and Interface Updates:
* Introduced `ConversationEncryptionRequest` and `ConversationEncryptionPublic` types to represent encryption metadata in requests and responses. [[1]](diffhunk://#diff-04bd43e553cbe82c8893c09d79b008b4414a682afed8e2ad576f3d3abade8de0R1-R11) [[2]](diffhunk://#diff-2207adf04b1625b0053b2f0685b74ff07c7129dae2dcf46d66f167efd9e80c96R21)
* Updated `ConversationPublic` and `ConversationStatusPublic` interfaces to include encryption metadata. [[1]](diffhunk://#diff-2207adf04b1625b0053b2f0685b74ff07c7129dae2dcf46d66f167efd9e80c96R21) [[2]](diffhunk://#diff-0ead958ef3acf802bd6e90f11db0dda83a1721c00b54418161d208d2bfca43f5L11-R13)

### Migration Fixes:
* Refactored the `encryption_metadata` table to drop unused columns (`conversation_id`, `created_at`, `encryptionKey`, `updated_at`) and added new fields (`mac`, `version`, `createdAt`).…models, and tests